### PR TITLE
fix: separate show "now loading" task to a class to avoid capture variable…

### DIFF
--- a/ZipPicViewUWP/MainPage.xaml.cs
+++ b/ZipPicViewUWP/MainPage.xaml.cs
@@ -2,14 +2,13 @@
 // Copyright (c) Wutipong Wongsakuldej. All rights reserved.
 // </copyright>
 
-using System.Threading;
-
 namespace ZipPicViewUWP
 {
     using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Windows.ApplicationModel.DataTransfer;
     using Windows.Storage;


### PR DESCRIPTION
… being modify warning.